### PR TITLE
Miso 4104 - 2 parameter shift / adstock transformation

### DIFF
--- a/lightweight_mmm/lightweight_mmm.py
+++ b/lightweight_mmm/lightweight_mmm.py
@@ -365,18 +365,12 @@ class LightweightMMM:
         target_accept_prob=target_accept_prob,
         init_strategy=init_strategy )
 
-    # from numpyro.infer import ESS, AIES
-    # kernel = ESS( model=self._model_function, moves={ ESS.DifferentialMove() : 0.8,
-    #                            ESS.RandomMove() : 0.2} )
-    # kernel = AIES(model=self._model_function, moves={ AIES.DEMove() : 0.5,
-    #                                                    AIES.StretchMove() : 0.5 } )
-
     mcmc = numpyro.infer.MCMC(
         sampler=kernel,
         num_warmup=number_warmup,
         num_samples=number_samples,   # number_samples | 1500
         num_chains=number_chains,     # number_chains
-        chain_method='vectorized' )   # 'parallel'
+        chain_method='parallel' )     # 'parallel'
 
     mcmc.run(
         rng_key=jax.random.PRNGKey(seed),

--- a/lightweight_mmm/media_transforms.py
+++ b/lightweight_mmm/media_transforms.py
@@ -66,214 +66,7 @@ def calculate_seasonality(
   return (season_matrix * gamma_seasonality).sum(axis=2).sum(axis=1)
 
 
-# karl begin
-
-#
-# wrapper for evaluating the Geometric Decay function
-# using JAX primitives
-#
-def geo_f( lam, t, scaler = 1.0 ):
-    return jnp.exp( -1.0 * scaler * lam * t )
-
-
-from jax import custom_jvp
-
-#
-# computes the shifted geometric weights for applying the adstock
-#
-@custom_jvp
-def compute_weights_host( lam ):
-
-    pct=0.5
-    scaler = 1.0
-    max_week=13.0
-    max_horizon=100
-
-    bVerbose = False
-
-    if bVerbose:
-        print( 'CWH(): BEGIN METHOD' )
-
-    def geo_f_local( lam, t, scaler = 1.0 ):
-        return np.exp( -1.0 * scaler * lam * t )
-
-    ret_val = np.zeros( int(max_week+1), dtype=np.float32 )
-    norm_const = integrate.quad( geo_f_local, 0, max_horizon, args=(lam) )[0]
-    # print( "norm_const: ", norm_const )
-    t = np.arange( 0.0, max_week, 0.1 )
-    res = max_week
-    for x in range(len(t)):
-        v = (integrate.quad( geo_f_local, 0, t[x], args=(lam, scaler) )[0] / norm_const)
-        if v > (1.0-pct):
-            res = t[x]
-            break
-
-    mean_point = res
-    mean_time = res
-    cur_week = math.ceil( res )
-    for weekIdx in range( cur_week, 0, -1 ):
-        startPt = max( res - 1.0, 0 )
-        # print( "weekIdx[", weekIdx, "]: ", startPt,  " | ", res )
-        v = (integrate.quad( geo_f_local, startPt, res, args=(lam, scaler) )[0] / norm_const)
-        res = res - 1.0
-        ret_val[ weekIdx-1 ] = v
-
-    for weekIdx in range( cur_week, int(max_week) ):
-        endPt = (mean_time+1) if weekIdx < (max_week-1) else max_horizon
-        v = (integrate.quad( geo_f_local, mean_time, endPt, args=(lam, scaler) )[0] / norm_const)
-        mean_time = mean_time + 1.0
-        ret_val[ weekIdx ] = v
-
-    ret_val[ int(max_week) ] = mean_point
-    if bVerbose:
-        print( 'CWH(): ', ret_val )
-    return ret_val
-
-
-# code copying
-cwh = jax.custom_jvp( compute_weights_host )
-
-#
-# JVP callback
-#
-@compute_weights_host.defjvp
-def compute_weights_host_jvp( primals, tangents ):
-    print( "compute_weights_host_jvp(): primals: ", primals )
-    print( "compute_weights_host_jvp(): tangents: ", tangents )
-    lam   = primals
-    x_dot = tangents
-    primal_out = compute_weights_host( lam )
-    tangent_out = -1 * lam * jnp.multiply( primal_out, x_dot )
-    return primal_out, tangent_out
-
-
-#
-# pct=0.5, scaler = 1.0, max_week=13.0, max_horizon=100
-#
-def compute_weights_wrapper(  lam ):
-    result_shape = jax.ShapeDtypeStruct( (13+1,), lam.dtype )
-    return jax.pure_callback( cwh, result_shape, lam )
-
-
-#
-# performs the actual work of distributing the spend according to the
-# weights and the provided shift value.
-#
-@custom_jvp
-def distribute_weights( shifted_weights, mean_week, colData, colDataLen, weeks ):
-    # print( 'distribute_weights(): BEGIN' )
-
-    bVerbose = False
-
-    rev_shift_start = math.ceil( mean_week )  # week index where spend is carried forward
-
-    # print( 'distribute_weights: shape=', np.shape(colData) )
-    # print( 'distribute_weights: weeks  : ', weeks )
-
-    colDataOut = np.zeros( np.shape(colData), dtype=np.float32 )
-
-    for dIdx in range( 0, colDataLen ):
-        mul_data    = np.ones( weeks, dtype=np.float32 )
-        spnd_data   = mul_data * colData[dIdx]
-        split_spend = np.multiply( spnd_data, shifted_weights )
-
-        if bVerbose:
-            print( "-------- dIdx: ", dIdx, " -------------------------: split spend type: ", type(split_spend) )
-
-        # find start index of xform_data
-        sIdx = max( (-1*rev_shift_start) + dIdx, 0 )
-        # find start index of weights
-        weightsIdx = np.where( dIdx >= rev_shift_start, 0, (rev_shift_start - dIdx) )
-
-        if bVerbose:
-            print( "weightsIdx: ", weightsIdx, " | ", jnp.shape( weightsIdx ) )
-
-        eIdx = (sIdx + weeks - weightsIdx)
-        if bVerbose:
-            print( '    sIdx: ', sIdx, ' -> eIdx: ', eIdx )
-        weightsEnd = -1
-        # eIdx = min( colDataLen, eIdx )
-        if eIdx > colDataLen:
-            weightsEnd = len(split_spend) - (eIdx-colDataLen)
-
-        split_spend  = split_spend[weightsIdx:weightsEnd]
-
-        leftPad      = sIdx
-        rightPad     = colDataLen - sIdx - len(split_spend)
-
-        if bVerbose:
-            print( '    split_spend (final): ', split_spend, " | ", len(split_spend), " | weightsEndIdx: ", weightsEnd )
-            print( '    pads: ',  (leftPad,rightPad) )
-
-        padded_spend = np.pad( split_spend, (leftPad,rightPad) )
-
-        if bVerbose:
-            print( '    len padded spend: ', len(padded_spend) )
-
-        colDataOut   = np.add( colDataOut, padded_spend )
-
-    if bVerbose:
-        print( 'distribute_weights(END): colDataOut: (final): ', np.shape(colDataOut), "|", type(colDataOut) )
-
-    return np.array( colDataOut, dtype=np.float32 )
-
-
-#
-dw = jax.custom_jvp( distribute_weights )
-
-
-#
-# JVP callback
-#
-@distribute_weights.defjvp
-def distribute_weights_host_jvp( primals, tangents ):
-    print( "distribute_weights_host_jvp(): primals: ", primals )
-    print( "distribute_weights_host_jvp(): tangents: ", tangents )
-    shifted_weights, mean_week, colData, colDataLen, weeks = primals
-    x_dot = tangents
-    primal_out = distribute_weights( shifted_weights, mean_week, colData, colDataLen, weeks )
-    tangent_out = -1 * jnp.multiply( primal_out, x_dot )
-    return primal_out, tangent_out
-
-
-#
-# implemented shift logic as JAX Callback since the shift amount comes out of
-#   a sampled variable.
-#
-def distribute_weights_wrapper( shifted_weights, mean_week, colData, colDataLen, weeks ):
-    result_shape = jax.ShapeDtypeStruct( jnp.shape(colData), colData.dtype )
-    return jax.pure_callback( distribute_weights, result_shape, shifted_weights, mean_week, colData, colDataLen, weeks )
-
-
-#
-# compute standard (unshifted) weights for geometric adstock
-#
-@jax.jit
-def compute_std_weights( lam ):
-    scaler = 1.0
-    max_week=13.0
-    max_horizon=100
-
-    ret_val = jnp.zeros( int(max_week) )
-    # norm_const = jintegrate.quad( geo_f, 0, max_horizon, args=(lam) )[0]
-    x = jnp.linspace( 0, max_horizon, 100 )
-    y = geo_f( lam, x )
-    norm_const = jnp.sum( jintegrate.trapezoid( y, x ) )
-    # print( "norm_const: ", norm_const )
-
-    mean_time = 0
-    for weekIdx in range( 0, int(max_week) ):
-        # endPt = (mean_time+1) if weekIdx < (max_week-1) else max_horizon
-        endPt = jnp.where( weekIdx < (max_week-1), (mean_time+1), max_horizon )
-        x = jnp.linspace( mean_time, endPt, 10 )
-        y = geo_f( lam, x )
-        v = jnp.sum( jintegrate.trapezoid( y, x ) / norm_const )
-        mean_time = mean_time + 1.0
-        ret_val = ret_val.at[ weekIdx ].set(v)
-
-    return ret_val
-
-#
+# convolution definitions that can enable backwards shift
 CONV_SIZE = 25
 NUM_WEEKS = 13
 
@@ -295,22 +88,13 @@ def create_zeros_wrapper( pad_size, weights ):
     return jax.pure_callback( create_zeros_host, result_shape, pad_size, weights )
 
 
-
-# Define the main function that performs padding
-#@jax.custom_vjp
-#def custom_pad(x, p_left, p_right):
-#    return jnp.pad(x, (p_left, p_right))
-
 # Define the forward pass
 # weights are of dim 13, overall convolution array of len 21
 def custom_pad_fwd( pad_size, w ):
     p_left  = pad_size
     p_right = CONV_SIZE - NUM_WEEKS - p_left
-    # y = jnp.pad( w, (p_left, p_right) )
+    # delegate to user space callback
     y = create_zeros_wrapper( pad_size, w )
-
-    # Compute the output (padded array)
-    # y = jnp.pad( x, (p_left, p_right) )
 
     shp = jnp.shape(w)
     # print( 'shape w: ', shp, " pad size: ", pad_size )
@@ -326,8 +110,7 @@ def custom_pad_bwd( res, g ):
 
     # Extract the gradient for the output (g)
     # Only the middle part (corresponding to the original x) of g contributes to the gradient of x
-    # grad_x = g[ p_left : p_left + n ]
-    # grad_x = jax.lax.dynamic_slice( g, p_left, n - p_right )
+    # the middle part is 'w'
     grad_x = w
 
     # Since pad is not an inputs that we differentiate with respect to,
@@ -351,13 +134,11 @@ create_zeros_wrapper.defvjp( custom_pad_fwd, custom_pad_bwd )
 def run_reverse_shift( num_weeks, lag_weight, shift_weeks, colData ):
     # print( "run reverse shift: BEGIN: ", num_weeks )
 
-    # left pad of maximum value (in this case 8) indicates no shift
+    # left pad of maximum value indicates no shift
     shift_weeks = CONV_SIZE - NUM_WEEKS - shift_weeks
     shift_weeks = jnp.minimum( (CONV_SIZE - NUM_WEEKS), shift_weeks )
     shift_weeks = jnp.maximum( 0.0, shift_weeks )
     pad = jnp.round( shift_weeks ).astype(int)
-
-    # print( "rrs(): lag_weight: ", lag_weight, " num_weeks: ", num_weeks )
 
     lag_weights_arr = jnp.ones( NUM_WEEKS )
     lag_weights_arr = lag_weights_arr * lag_weight
@@ -368,45 +149,6 @@ def run_reverse_shift( num_weeks, lag_weight, shift_weeks, colData ):
     weights = create_zeros_wrapper( pad, weights )
 
     return jax.scipy.signal.convolve( colData, weights, mode="same" )
-
-#
-# run a straightforward Geometric adstock shift, on a column by column basis.
-# The idea behind this is that some Channels (columns) follow a standard shift while others
-#   require backwards shift in conjunction with adstock weights.
-#
-@functools.partial( jax.jit ) # , static_argnums=[0,1]
-def run_std_shift( num_weeks, lag_weight, shift_weeks, origSpend ):
-
-    # print( "run_std_shift: BEGIN: ", num_weeks )
-
-    # std_weights = compute_std_weights( lag_weight )
-    std_weights = jnp.power( lag_weight * jnp.ones(NUM_WEEKS), jnp.arange(NUM_WEEKS, dtype=jnp.float32) )
-    std_weights = std_weights / jnp.sum( std_weights )
-
-    # print( "run_std_shift(): colData: ", origSpend, ", weeks: ", num_weeks, " len(colData): " )
-    # print( "run_std_shift() std weights: ", std_weights )
-    # print( "sum std weights: ", sum(std_weights) )
-
-    colData = jnp.zeros( jnp.shape( origSpend )  )
-
-    # process standard normalized weights
-    inspColDataLen = len(colData)
-    # print(  'inspColDataLen: ', inspColDataLen )
-
-    for dIdx in range(0, len(colData)):
-        # print( "dIdx: ", dIdx )
-        mul_data    = jnp.ones( 13 )
-        spnd_data   = mul_data * origSpend[dIdx]
-        split_spend = jnp.multiply( spnd_data, std_weights )
-
-        wIdx = 0
-        range_limit = min( dIdx + 13, inspColDataLen )
-        # print( "range_limit: ", range_limit )
-        for npIdx in range( dIdx, range_limit ):
-            colData = colData.at[ npIdx ].add( split_spend[wIdx] )
-            wIdx = wIdx + 1
-
-    return colData
 
 
 #
@@ -449,46 +191,25 @@ def radstock( data: jnp.ndarray,
 
     #
     jnp_ret = None
-    xform_data = jnp.zeros( np.shape(data) )
-    xdataT = xform_data.T
     dataT  = data.T
 
-
     for colIdx in range( 0, len(dataT) ):
-        # print( 'lag_weight: ', lag_weight[ colIdx ], " type: ", type(lag_weight) )
-        # col_lag_weight = float( lag_weight[ colIdx ] )
-
         col_lag_weight = lag_weight[ colIdx ]
         col_shift      = shift_weeks[ colIdx ]
-
         origSpend  = dataT[ colIdx ]
-        # colData    = xdataT[ colIdx ]
-        # colDataLen = jnp.shape(colData)[0]
-        # print( 'colData shape: ', colDataLen )
 
-        # branch to either normal adstock
-        #
-        # args = dict( my_weeks= my_weeks, colIdx=colIdx, col_lag_weight= col_lag_weight, orig_spen= origSpend )
-        #branch_res = jax.lax.cond( enableReverseShift[colIdx], run_reverse_shift, run_std_shift,
-        #                           my_weeks, col_lag_weight, col_shift, origSpend )
-
-        #
         branch_res = run_reverse_shift( my_weeks, col_lag_weight, col_shift, origSpend )
 
         if jnp_ret is None:
             jnp_ret = branch_res
         else:
-            # print( 'jnp_ret: ', jnp.shape( jnp_ret ), " , branch_res: ", jnp.shape( branch_res ) )
             jnp_ret = jnp.vstack( (jnp_ret, branch_res) )
 
     jnp_ret = jnp.array( jnp_ret.T )
 
-    print( 'radstock(): final shape: ', jnp.shape( jnp_ret ) )
+    # print( 'radstock(): final shape: ', jnp.shape( jnp_ret ) )
 
     return  jnp_ret
-
-# karl end
-
 
 
 @jax.jit

--- a/lightweight_mmm/models.py
+++ b/lightweight_mmm/models.py
@@ -294,8 +294,6 @@ def transform_carryover(media_data: jnp.ndarray,
   return media_transforms.apply_exponent_safe(data=carryover, exponent=exponent)
 
 
-## begin karl
-
 def transform_hill_radstock(media_data: jnp.ndarray,
                            custom_priors: MutableMapping[str, Prior],
                            normalise: bool = True,
@@ -356,8 +354,6 @@ def transform_hill_radstock(media_data: jnp.ndarray,
             normalise=normalise, enableReverseShift=enableReverseShift ),
         half_max_effective_concentration=half_max_effective_concentration,
         slope=slope)
-
-## end karl
 
 
 def media_mix_model(

--- a/lightweight_mmm/models.py
+++ b/lightweight_mmm/models.py
@@ -147,7 +147,7 @@ def _get_transform_default_priors() -> Mapping[str, Prior]:
               _SLOPE:
                   dist.Gamma(concentration=1., rate=1.),
               _SHIFT:
-                  dist.Beta(concentration1=1.,concentration0=100.)
+                  dist.Gamma(concentration=1., rate=100.)
           })
   })
 


### PR DESCRIPTION
Added code to support a 2 parameter shift / adstock transformation, where one parameter controls the geometric decay, and the other parameter controls the amount of shift backwards in time, suitable for CPA channels.

The benefit of this approach is that the higher-than-plausible correlation between CPA channels and conversions/sales is reduced, and the model becomes more believable with respect to this family of channels.